### PR TITLE
In geospatial_lat_min/max and geospatial_vertical_min/max type checks…

### DIFF
--- a/compliance_checker/imos/imos.py
+++ b/compliance_checker/imos/imos.py
@@ -31,6 +31,7 @@ class IMOSCheck(BaseNCCheck):
     """
     register_checker = True
     name = 'imos'
+    float_type = [np.float64, np.float, np.float32, np.float16, np.float128]
 
     CHECK_VARIABLE = 1
     CHECK_GLOBAL_ATTRIBUTE = 0
@@ -185,7 +186,7 @@ class IMOSCheck(BaseNCCheck):
         if result.value:
             result_name = ('globalattr', 'geospatial_lat_min', 'check_attribute_type')
             result = check_attribute_type(('geospatial_lat_min',),
-                                        np.number,
+                                        IMOSCheck.float_type,
                                         dataset,
                                         IMOSCheck.CHECK_GLOBAL_ATTRIBUTE,
                                         result_name,
@@ -209,7 +210,7 @@ class IMOSCheck(BaseNCCheck):
 
             result_name = ('globalattr', 'geospatial_lat_max', 'check_attribute_type')
             result2 = check_attribute_type(('geospatial_lat_max',),
-                                            np.number,
+                                            IMOSCheck.float_type,
                                             dataset,
                                             IMOSCheck.CHECK_GLOBAL_ATTRIBUTE,
                                             result_name,
@@ -247,7 +248,7 @@ class IMOSCheck(BaseNCCheck):
         if result.value:
             result_name = ('globalattr', 'geospatial_lon_min', 'check_attribute_type')
             result = check_attribute_type(('geospatial_lon_min',),
-                                            np.number,
+                                            IMOSCheck.float_type,
                                             dataset,
                                             IMOSCheck.CHECK_GLOBAL_ATTRIBUTE,
                                             result_name,
@@ -271,7 +272,7 @@ class IMOSCheck(BaseNCCheck):
 
             result_name = ('globalattr', 'geospatial_lon_max', 'check_attribute_type')
             result2 = check_attribute_type(('geospatial_lon_max',),
-                                            np.number,
+                                            IMOSCheck.float_type,
                                             dataset,
                                             IMOSCheck.CHECK_GLOBAL_ATTRIBUTE,
                                             result_name,
@@ -309,7 +310,7 @@ class IMOSCheck(BaseNCCheck):
         if result.value:
             result_name = ('globalattr', 'geospatial_vertical_min', 'check_attribute_type')
             result = check_attribute_type(('geospatial_vertical_min',),
-                                            np.number,
+                                            IMOSCheck.float_type,
                                             dataset,
                                             IMOSCheck.CHECK_GLOBAL_ATTRIBUTE,
                                             result_name,
@@ -333,7 +334,7 @@ class IMOSCheck(BaseNCCheck):
 
             result_name = ('globalattr', 'geospatial_vertical_max', 'check_attribute_type')
             result2 = check_attribute_type(('geospatial_vertical_max',),
-                                            np.number,
+                                            IMOSCheck.float_type,
                                             dataset,
                                             IMOSCheck.CHECK_GLOBAL_ATTRIBUTE,
                                             result_name,


### PR DESCRIPTION
…, replaced type numpy.number by all the possible float types in numpy.
