### PR TITLE
TEMPORARY FIX: logic error in check_flags when checking flag_masks

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -800,7 +800,7 @@ class CFBaseCheck(BaseCheck):
                 if len(zeros):
                     msgs = ['flag_masks attribute values contains a zero']
 
-                ret_val.append(Result(BaseCheck.HIGH, len(zeros) != 0, ('flags', k, 'flag_masks_zeros'), msgs=msgs))
+                ret_val.append(Result(BaseCheck.HIGH, len(zeros) == 0, ('flags', k, 'flag_masks_zeros'), msgs=msgs))
 
             # 9) when both defined, boolean AND of each entry in flag_values with corresponding entry in flag_masks
             #    should equal the flags_value entry


### PR DESCRIPTION
This needs to be fixed properly in IOOS master branch, but I'm doing it here so we can deploy it, as it is holding up the publication of ANMN acidification moorings data.
