### PR TITLE
Fix duplicate axis message consistency on Py 2/3

### DIFF
--- a/compliance_checker/cf/cf.py
+++ b/compliance_checker/cf/cf.py
@@ -2160,7 +2160,7 @@ class CFBaseCheck(BaseCheck):
             for axis, coords in axis_map.items():
                 coords = [c for c in coords if hasattr(ds.variables[c], 'axis')]
                 no_duplicates.assert_true(len(coords) <= 1,
-                                          "'{}' has duplicate axis {} defined by {}".format(name, axis, sorted(coords))
+                                          "'{}' has duplicate axis {} defined by [{}]".format(name, axis, ', '.join(sorted(coords)))
                                           )
 
             ret_val.append(no_duplicates.to_result())

--- a/compliance_checker/tests/test_cf.py
+++ b/compliance_checker/tests/test_cf.py
@@ -962,7 +962,7 @@ class TestCF(BaseTestCase):
 
         # only one check run here, so we can directly compare all the values
         assert scored != out_of
-        assert messages[0] == u"'temp' has duplicate axis X defined by [u'lon_rho', u'lon_u']"
+        assert messages[0] == u"'temp' has duplicate axis X defined by [lon_rho, lon_u]"
 
     def test_check_multi_dimensional_coords(self):
         '''


### PR DESCRIPTION
Fixes a duplicate axis message and associated unit test which previously
returned a `repr()` of a list of Unicode strings, which led to different
messages under Python 2 and 3.  This previously caused unit test failure
under Python 3, but is fixed by joining the list contents with the `', '`
string.